### PR TITLE
Enable Hackage-friendly stack.yaml settings

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -5,3 +5,4 @@ packages:
 extra-deps:
 - haskell-qrencode-1.0.4
 resolver: lts-7.14
+pvp-bounds: both


### PR DESCRIPTION
This is basically the same problem as already described in https://github.com/vmchale/command-line-tweeter/pull/1

See also https://hackage.haskell.org/package/qr-imager-0.2.1.0/reports/


